### PR TITLE
fix chapters sorting - make integer sort instead of default alphabetical 

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -64,7 +64,9 @@ export function middleware (request) {
       }
 
       return acc
-    }, []).sort().join(',')
+    }, []).sort(function(a,b){
+		return parseInt(a)-parseInt(b);
+	} ).join(',')
 
     if (validatedChapters !== params.chapters) {
       params.chapters = validatedChapters || '*'


### PR DESCRIPTION
Chapters filter sort alphabetically (e.g. "3,2,10,28" becomes "10,2,28,3" in the URL and filter).

The fix makes sort() function to sort based on the parsed integers, instead of default alphabetical order